### PR TITLE
Qunit check nolint

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "ember-load-initializers": "^2.1.2",
     "ember-modifier": "^4.1.0",
     "ember-page-title": "^8.0.0",
-    "ember-qunit": "^8.0.1",
+    "ember-qunit": "nelstrom/ember-qunit#remove-nolint-ui",
     "ember-resolver": "^11.0.1",
     "ember-source": "~5.3.0",
     "ember-template-lint": "^5.11.2",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "ember-load-initializers": "^2.1.2",
     "ember-modifier": "^4.1.0",
     "ember-page-title": "^8.0.0",
-    "ember-qunit": "nelstrom/ember-qunit#remove-nolint-ui",
+    "ember-qunit": "https://gitpkg.now.sh/nelstrom/ember-qunit/addon?remove-nolint-ui",
     "ember-resolver": "^11.0.1",
     "ember-source": "~5.3.0",
     "ember-template-lint": "^5.11.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,8 +81,8 @@ devDependencies:
     specifier: ^8.0.0
     version: 8.0.0
   ember-qunit:
-    specifier: ^8.0.1
-    version: 8.0.1(@ember/test-helpers@3.2.0)(ember-source@5.3.0)(qunit@2.20.0)
+    specifier: nelstrom/ember-qunit#remove-nolint-ui
+    version: github.com/nelstrom/ember-qunit/eb2aa476e9245e5196f9ee34d31844a856e494d1
   ember-resolver:
     specifier: ^11.0.1
     version: 11.0.1(ember-source@5.3.0)
@@ -5114,15 +5114,6 @@ packages:
       ember-cli-string-utils: 1.1.0
     dev: true
 
-  /ember-cli-test-loader@3.1.0:
-    resolution: {integrity: sha512-0aocZV9SIoOHiU3hrH3IuLR6busWhTX6UVXgd490hmJkIymmOXNH2+jJoC7Ebkeo3PiOfAdjqhb765QDlHSJOw==}
-    engines: {node: 10.* || >= 12}
-    dependencies:
-      ember-cli-babel: 7.26.11
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /ember-cli-typescript-blueprint-polyfill@0.1.0:
     resolution: {integrity: sha512-g0weUTOnHmPGqVZzkQTl3Nbk9fzEdFkEXydCs5mT1qBjXh8eQ6VlmjjGD5/998UXKuA0pLSCVVMbSp/linLzGA==}
     dependencies:
@@ -5488,24 +5479,6 @@ packages:
     dependencies:
       '@embroider/addon-shim': 1.8.6
     transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /ember-qunit@8.0.1(@ember/test-helpers@3.2.0)(ember-source@5.3.0)(qunit@2.20.0):
-    resolution: {integrity: sha512-13PtywHNPTQKkDW4o8QRkJvcdsZr8hRyvh6xh/YLAX8+HaRLd3nPL8mBF4O/Kur/DAj3QWLvjzktZ2uRNGSh3A==}
-    peerDependencies:
-      '@ember/test-helpers': '>=3.0.3'
-      ember-source: '>=4.0.0'
-      qunit: ^2.13.0
-    dependencies:
-      '@ember/test-helpers': 3.2.0(ember-source@5.3.0)(webpack@5.88.2)
-      '@embroider/addon-shim': 1.8.6
-      '@embroider/macros': 1.13.1
-      ember-cli-test-loader: 3.1.0
-      ember-source: 5.3.0(@babel/core@7.23.0)(@glimmer/component@1.1.2)(rsvp@4.8.5)(webpack@5.88.2)
-      qunit: 2.20.0
-    transitivePeerDependencies:
-      - '@glint/template'
       - supports-color
     dev: true
 
@@ -11550,4 +11523,12 @@ packages:
   /yocto-queue@1.0.0:
     resolution: {integrity: sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==}
     engines: {node: '>=12.20'}
+    dev: true
+
+  github.com/nelstrom/ember-qunit/eb2aa476e9245e5196f9ee34d31844a856e494d1:
+    resolution: {tarball: https://codeload.github.com/nelstrom/ember-qunit/tar.gz/eb2aa476e9245e5196f9ee34d31844a856e494d1}
+    name: root
+    version: 0.0.0
+    prepare: true
+    requiresBuild: true
     dev: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,8 +81,8 @@ devDependencies:
     specifier: ^8.0.0
     version: 8.0.0
   ember-qunit:
-    specifier: nelstrom/ember-qunit#remove-nolint-ui
-    version: github.com/nelstrom/ember-qunit/eb2aa476e9245e5196f9ee34d31844a856e494d1
+    specifier: https://gitpkg.now.sh/nelstrom/ember-qunit/addon?remove-nolint-ui
+    version: '@gitpkg.now.sh/nelstrom/ember-qunit/addon?remove-nolint-ui(@ember/test-helpers@3.2.0)(ember-source@5.3.0)(qunit@2.20.0)'
   ember-resolver:
     specifier: ^11.0.1
     version: 11.0.1(ember-source@5.3.0)
@@ -5112,6 +5112,15 @@ packages:
     resolution: {integrity: sha512-dEVTIpmUfCzweC97NGf6p7L6XKBwV2GmSM4elmzKvkttEp5P7AvGA9uGyN4GqFq+RwhW+2b0I2qlX00w+skm+A==}
     dependencies:
       ember-cli-string-utils: 1.1.0
+    dev: true
+
+  /ember-cli-test-loader@3.1.0:
+    resolution: {integrity: sha512-0aocZV9SIoOHiU3hrH3IuLR6busWhTX6UVXgd490hmJkIymmOXNH2+jJoC7Ebkeo3PiOfAdjqhb765QDlHSJOw==}
+    engines: {node: 10.* || >= 12}
+    dependencies:
+      ember-cli-babel: 7.26.11
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /ember-cli-typescript-blueprint-polyfill@0.1.0:
@@ -11525,10 +11534,23 @@ packages:
     engines: {node: '>=12.20'}
     dev: true
 
-  github.com/nelstrom/ember-qunit/eb2aa476e9245e5196f9ee34d31844a856e494d1:
-    resolution: {tarball: https://codeload.github.com/nelstrom/ember-qunit/tar.gz/eb2aa476e9245e5196f9ee34d31844a856e494d1}
-    name: root
-    version: 0.0.0
-    prepare: true
-    requiresBuild: true
+  '@gitpkg.now.sh/nelstrom/ember-qunit/addon?remove-nolint-ui(@ember/test-helpers@3.2.0)(ember-source@5.3.0)(qunit@2.20.0)':
+    resolution: {tarball: https://gitpkg.now.sh/nelstrom/ember-qunit/addon?remove-nolint-ui}
+    id: '@gitpkg.now.sh/nelstrom/ember-qunit/addon?remove-nolint-ui'
+    name: ember-qunit
+    version: 8.0.1
+    peerDependencies:
+      '@ember/test-helpers': '>=3.0.3'
+      ember-source: '>=4.0.0'
+      qunit: ^2.13.0
+    dependencies:
+      '@ember/test-helpers': 3.2.0(ember-source@5.3.0)(webpack@5.88.2)
+      '@embroider/addon-shim': 1.8.6
+      '@embroider/macros': 1.13.1
+      ember-cli-test-loader: 3.1.0
+      ember-source: 5.3.0(@babel/core@7.23.0)(@glimmer/component@1.1.2)(rsvp@4.8.5)(webpack@5.88.2)
+      qunit: 2.20.0
+    transitivePeerDependencies:
+      - '@glint/template'
+      - supports-color
     dev: true


### PR DESCRIPTION
To test ember-qunit#1140, I've run `ember new` and replaced the `ember-qunit` version with the one from the `nelstrom:remove-nolint-ui` branch.